### PR TITLE
Add estimated dV and time in parking orbit

### DIFF
--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -287,23 +287,18 @@ namespace LunarTransferPlanner
             double targetTime = Planetarium.GetUniversalTime() + flightTime * 24d * 3600d + delayTime;
             Vector3d targetPos = target.getPositionAtUT(targetTime);
 
-            Vector3d upVector = QuaternionD.AngleAxis(delayTime * 360d / mainBody.rotationPeriod, EarthAxis) * (launchPos - EarthPos).normalized;
+            Vector3d upVector = Quaternion.AngleAxis((float)(delayTime * 360d / mainBody.rotationPeriod), EarthAxis) * (launchPos - EarthPos).normalized;
 
             Vector3d orbitNorm = Vector3d.Cross(targetPos - EarthPos, upVector).normalized;
-            double inclination = Math.Acos(Vector3d.Dot(orbitNorm, EarthAxis));
+            double inclination = Math.Acos(Vector3d.Dot(orbitNorm, mainBody.angularVelocity.normalized));
             if (inclination > Math.PI / 2)
-            {
                 inclination = Math.PI - inclination;
-                orbitNorm *= -1; // make sure orbitNorm always points roughly northwards
-            }
 
-            // When checking this: remember that Unity (and KSP) use a left-handed coordinate system; therefore, the
-            // cross product follows the left-hand rule.
-            Vector3d eastVec = Vector3d.Cross(upVector, EarthAxis).normalized;
-            Vector3d northVec = Vector3d.Cross(eastVec, upVector).normalized;
-            Vector3d launchVec = Vector3d.Cross(upVector, orbitNorm).normalized;
+            Vector3d eastVec = Vector3d.Cross(EarthAxis, upVector).normalized;
 
             double azimuth = Math.Acos(Vector3d.Dot(launchVec, northVec));
+            if (Vector3d.Dot(launchVec, eastVec) < 0d)
+                azimuth = Math.PI - azimuth;
 
             return new OrbitData(orbitNorm, inclination * 180d / Math.PI, azimuth * 180d / Math.PI);
         }

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -645,10 +645,6 @@ namespace LunarTransferPlanner
                     GUILayout.Box(new GUIContent(String.Format("{0:0 m/s}", dV), "Required dV for the selected flight time"), GUILayout.MinWidth(100));
 
                     GUILayout.Space(4);
-                    GUILayout.Label("Latitude", GUILayout.ExpandWidth(true));
-                    GUILayout.Box(new GUIContent(String.Format("{0:0.00}\u00B0", latitude), "Latitude of current launch site"), GUILayout.MinWidth(100));
-
-                    GUILayout.Space(4);
                     GUILayout.BeginHorizontal();
                     GUILayout.Label("Launch Now Incl", GUILayout.ExpandWidth(true));
                     bool showParking0_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -295,6 +295,8 @@ namespace LunarTransferPlanner
                 inclination = Math.PI - inclination;
 
             Vector3d eastVec = Vector3d.Cross(EarthAxis, upVector).normalized;
+            Vector3d northVec = Vector3d.Cross(eastVec, upVector).normalized;
+            Vector3d launchVec = Vector3d.Cross(upVector, orbitNorm).normalized;
 
             double azimuth = Math.Acos(Vector3d.Dot(launchVec, northVec));
             if (Vector3d.Dot(launchVec, eastVec) < 0d)

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -287,20 +287,23 @@ namespace LunarTransferPlanner
             double targetTime = Planetarium.GetUniversalTime() + flightTime * 24d * 3600d + delayTime;
             Vector3d targetPos = target.getPositionAtUT(targetTime);
 
-            Vector3d upVector = Quaternion.AngleAxis((float)(delayTime * 360d / mainBody.rotationPeriod), EarthAxis) * (launchPos - EarthPos).normalized;
+            Vector3d upVector = QuaternionD.AngleAxis(delayTime * 360d / mainBody.rotationPeriod, EarthAxis) * (launchPos - EarthPos).normalized;
 
             Vector3d orbitNorm = Vector3d.Cross(targetPos - EarthPos, upVector).normalized;
-            double inclination = Math.Acos(Vector3d.Dot(orbitNorm, mainBody.angularVelocity.normalized));
+            double inclination = Math.Acos(Vector3d.Dot(orbitNorm, EarthAxis));
             if (inclination > Math.PI / 2)
+            {
                 inclination = Math.PI - inclination;
+                orbitNorm *= -1; // make sure orbitNorm always points roughly northwards
+            }
 
-            Vector3d eastVec = Vector3d.Cross(EarthAxis, upVector).normalized;
+            // When checking this: remember that Unity (and KSP) use a left-handed coordinate system; therefore, the
+            // cross product follows the left-hand rule.
+            Vector3d eastVec = Vector3d.Cross(upVector, EarthAxis).normalized;
             Vector3d northVec = Vector3d.Cross(eastVec, upVector).normalized;
             Vector3d launchVec = Vector3d.Cross(upVector, orbitNorm).normalized;
 
             double azimuth = Math.Acos(Vector3d.Dot(launchVec, northVec));
-            if (Vector3d.Dot(launchVec, eastVec) < 0d)
-                azimuth = Math.PI - azimuth;
 
             return new OrbitData(orbitNorm, inclination * 180d / Math.PI, azimuth * 180d / Math.PI);
         }
@@ -311,7 +314,7 @@ namespace LunarTransferPlanner
             double t = startTime;
             OrbitData launchOrbit = CalcOrbitForTime(target, launchPos, t);
 
-            if (latitude >= target.orbit.inclination)
+            if (Math.Abs(latitude) >= target.orbit.inclination)
             {
                 // High latitude path - find the next easterly launch to the target
                 while (Math.Abs(launchOrbit.azimuth - targetAz) > 0.01d)
@@ -651,7 +654,7 @@ namespace LunarTransferPlanner
                     GUILayout.Box(new GUIContent($"{(launchOrbit.azimuth > 90d ? -launchOrbit.inclination : launchOrbit.inclination):F2}\u00B0",
                         "Launch to this inclination now to reach a Lunar parking orbit"), GUILayout.MinWidth(100));
 
-                    string tooltip = latitude >= target.orbit.inclination ?
+                    string tooltip = Math.Abs(latitude) >= target.orbit.inclination ?
                         "Launch at this time for an Easterly launch to Lunar parking orbit" :
                         "Launch at this time for a low inclination launch to Lunar parking orbit";
 

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -86,15 +86,16 @@ namespace LunarTransferPlanner
         Rect        windowRect = new Rect(100,100,-1,-1);
         bool        isWindowOpen = true;
         // gui stuff
-        const float tliAltitudeKM = 200f;       // Parking orbit altitude (circular orbit assumed). Not so important to be in the GUI.
-        float       flightTime = 4f;
-        float       nextTickFT = 0f;
-        bool        showParking0 = false;       // Expand/collapse time in parking orbit for launch now
-        bool        showParking1 = false;       // Expand/collapse time in parking orbit for first window
-        bool        showParking2 = false;       // Expand/collapse time in parking orbit for second window
-        float       warpMargin = 60f;
-        float       nextTickWM = 0f;
-        string      windowTitle = "";
+        float flightTime = 4f;
+        float nextTickFT = 0f;
+        float tliAltitudeKM = 200f;       // Parking orbit altitude (circular orbit assumed)
+        float nextTickTA = 0f;
+        bool showParking0 = false;       // Expand/collapse time in parking orbit for launch now
+        bool showParking1 = false;       // Expand/collapse time in parking orbit for first window
+        bool showParking2 = false;       // Expand/collapse time in parking orbit for second window
+        float warpMargin = 60f;
+        float nextTickWM = 0f;
+        string windowTitle = "";
         GUISkin     skin;
 
 #region boring stuff
@@ -150,6 +151,7 @@ namespace LunarTransferPlanner
             settings.AddValue("windowRect.xMin", windowRect.xMin);
             settings.AddValue("windowRect.yMin", windowRect.yMin);
             settings.AddValue("flightTime", flightTime);
+            settings.AddValue("tliAltitudeKM", tliAltitudeKM);
             settings.AddValue("warpMargin", warpMargin);
             settings.Save(AssemblyLoader.loadedAssemblies.GetPathByType(typeof(LunarTransferPlanner)) + "/settings.cfg");
         }
@@ -164,6 +166,7 @@ namespace LunarTransferPlanner
                 Util.TryReadValue(ref x, settings, "windowRect.xMin");
                 Util.TryReadValue(ref y, settings, "windowRect.yMin");
                 Util.TryReadValue(ref flightTime, settings, "flightTime");
+                Util.TryReadValue(ref tliAltitudeKM, settings, "tliAltitudeKM");
                 Util.TryReadValue(ref warpMargin, settings, "warpMargin");
                 windowRect = new Rect(x, y, windowRect.width, windowRect.height);
                 LoadMutableToolbarSettings(settings);
@@ -616,18 +619,22 @@ namespace LunarTransferPlanner
 
                 windowTitle = "Lunar Transfer";
 
-                GUILayout.Space(4);
-                GUILayout.Label("Flight Time (days)", GUILayout.ExpandWidth(true));
-                MakeNumberEditField(ref flightTime, ref nextTickFT, 1, 0.1f, 0.1f);
-
                 CelestialBody target = FlightGlobals.fetch.bodies.FirstOrDefault(body => body.name.Equals("Moon", StringComparison.OrdinalIgnoreCase));
                 if (target == null)
                 {
                     GUILayout.Space(4);
-                    GUILayout.Box("Cannot find the Moon", GUILayout.MinWidth(80));
+                    GUILayout.Box("ERROR: Cannot find the Moon", GUILayout.MinWidth(80));
                 }
                 else
                 {
+                    GUILayout.Space(4);
+                    GUILayout.Label("Flight Time (days)", GUILayout.ExpandWidth(true));
+                    MakeNumberEditField(ref flightTime, ref nextTickFT, 1, 0.1f, 0.1f);
+
+                    GUILayout.Space(4);
+                    GUILayout.Label("Circ. Parking Orbit (km)", GUILayout.ExpandWidth(true));
+                    MakeNumberEditField(ref tliAltitudeKM, ref nextTickTA, 0, 5.0f, 140.0f);
+                    
                     double latitude = 0d;
                     Vector3d launchPos = GetLaunchPos(target.referenceBody, ref latitude);
 
@@ -643,7 +650,7 @@ namespace LunarTransferPlanner
 
                     GUILayout.Space(4);
                     GUILayout.BeginHorizontal();
-                    GUILayout.Label("Launch Now Incl", GUILayout.ExpandWidth(true));
+                    GUILayout.Label("Launch Now Incl.", GUILayout.ExpandWidth(true));
                     bool showParking0_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));
                     GUILayout.EndHorizontal();
 

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -645,6 +645,10 @@ namespace LunarTransferPlanner
                     GUILayout.Box(new GUIContent(String.Format("{0:0 m/s}", dV), "Required dV for the selected flight time"), GUILayout.MinWidth(100));
 
                     GUILayout.Space(4);
+                    GUILayout.Label("Latitude", GUILayout.ExpandWidth(true));
+                    GUILayout.Box(new GUIContent(String.Format("{0:0.00}\u00B0", latitude), "Latitude of current launch site"), GUILayout.MinWidth(100));
+
+                    GUILayout.Space(4);
                     GUILayout.BeginHorizontal();
                     GUILayout.Label("Launch Now Incl", GUILayout.ExpandWidth(true));
                     bool showParking0_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -63,6 +63,20 @@ namespace LunarTransferPlanner
             }
             return (float)((int)(x * lol)) / lol;
         }
+        
+        // Math.Acosh does not seem to work in .NET 4
+        public static double Acosh(double x)
+        {
+            if (x >= 1) 
+            {
+                return Math.Log(x + Math.Sqrt(x*x - 1));
+            }
+            else
+            {
+                return Double.NaN;
+            }
+            
+        }
     }
 
     [KSPAddon(KSPAddon.Startup.FlightAndKSC, false)]
@@ -72,8 +86,12 @@ namespace LunarTransferPlanner
         Rect        windowRect = new Rect(100,100,-1,-1);
         bool        isWindowOpen = true;
         // gui stuff
+        const float tliAltitudeKM = 200f;       // Parking orbit altitude (circular orbit assumed). Not so important to be in the GUI.
         float       flightTime = 4f;
         float       nextTickFT = 0f;
+        bool        showParking0 = false;       // Expand/collapse time in parking orbit for launch now
+        bool        showParking1 = false;       // Expand/collapse time in parking orbit for first window
+        bool        showParking2 = false;       // Expand/collapse time in parking orbit for second window
         float       warpMargin = 60f;
         float       nextTickWM = 0f;
         string      windowTitle = "";
@@ -383,6 +401,201 @@ namespace LunarTransferPlanner
             return t;
         }
 
+        private double EstimateFlightTimeAfterTLI(CelestialBody target, double dV, bool movingTarget = true)
+        {
+            CelestialBody mainBody = target.referenceBody;
+            double gravParameter = mainBody.gravParameter;
+
+            // The formulas are from http://www.braeunig.us/space/orbmech.htm
+
+            // Assuming that the TLI is performed from a circular orbit with altitude = tliAltitudeKM
+            // Radius of the orbit, including the radius of the Earth
+            double r0 = mainBody.Radius + tliAltitudeKM * 1000;
+
+            // Orbital velocity after TLI
+            double v0 = Math.Sqrt(gravParameter / r0) + dV;
+
+            // Eccentricity after TLI (not the full formula, this is correct only at the periapsis)
+            double e = r0 * v0*v0 / gravParameter - 1;
+
+            // e == 1 would mean that the orbit is parabolic. No idea which formulas are applicable in this case.
+            // But it's so unlikely that I will just cheat and make such orbits slightly hyperbolic.
+            if (e == 1) 
+            {
+                // Increase velocity after TLI  by 0.1 m/s
+                v0 = v0 + 0.1;          
+                // Recalculate eccentricity
+                e = r0 * v0*v0 / gravParameter - 1;     
+            }
+
+            // Semi-major axis after TLI
+            double a = 1 / (2/r0 - v0*v0 / gravParameter);
+                        
+            // Altitude of the Moon at the time of the TLI 
+            double r1 = 0;
+
+            // The Moon is moving, so we need to know its altitude when the probe arrives
+            // For that we need to know the flight time, which is being calculated here in the first place
+            // It can be done in two steps: 
+            // 1) make a recursive call of EstimateFlightTimeAfterTLI to find out the approximate flight time,
+            //    based on the Moon's current altitude
+            // 2) use the Moon's altitude at this approximate time for further calculations
+            if (movingTarget)
+            {
+                // This is the "normal" call of EstimateFlightTimeAfterTLI from outside
+
+                // Making the recursive call of EstimateFlightTimeAfterTLI with movingTarget = false
+                double approxFlightTime = EstimateFlightTimeAfterTLI(target, dV, false);
+
+                // Altitude of the Moon at the approximate time of the TLI 
+                r1 = target.orbit.GetRadiusAtUT(Planetarium.GetUniversalTime() + approxFlightTime);
+            }
+            else
+            {
+                // This is the recursive call of EstimateFlightTimeAfterTLI
+
+                // Altitude of the Moon now
+                r1 = target.orbit.GetRadiusAtUT(Planetarium.GetUniversalTime());
+            }
+
+            // True anomaly when the vessel reaches the altitude of the Moon (r1)
+            double trueAnomaly1 = Math.Acos( (a * (1 - e*e) - r1) / (e * r1) );
+
+            // Time until the vessel reaches the altitude of the Moon (r1)
+            double t1 = 0;
+
+            // Elliptic orbit after TLI
+            if (e < 1) 
+            {
+                // Eccentric Anomaly when the vessel reaches the altitude of the Moon
+                double eccAnomaly1 = Math.Acos( (e + Math.Cos(trueAnomaly1)) / (1 + e * Math.Cos(trueAnomaly1)) );
+                double meanAnomaly1 = eccAnomaly1 - e * Math.Sin(eccAnomaly1);
+                t1 = meanAnomaly1 / Math.Sqrt( gravParameter / (a*a*a) );
+            }
+
+            // Parabolic orbit (e == 1) has been prevented earlier
+
+            // Hyperbolic orbit
+            if (e > 1) 
+            {
+                // Hyperbolic Eccentric Anomaly when the vessel reaches the altitude of the Moon
+                // Can't use Math.Acosh, it does not seem to work in .NET 4
+                double hEccAnomaly1 = Util.Acosh( (e + Math.Cos(trueAnomaly1)) / (1 + e * Math.Cos(trueAnomaly1)) );
+
+                t1 = Math.Sqrt( ((-a)*(-a)*(-a)) / gravParameter ) * (e * Math.Sinh(hEccAnomaly1) - hEccAnomaly1);
+            }
+
+            return t1;
+        }
+
+        private double EstimateFlightTimeBeforeTLI(CelestialBody target, Vector3d launchPos, double delayTime)
+        {
+            CelestialBody mainBody = target.referenceBody;
+            double gravParameter = mainBody.gravParameter;
+
+            // This code is copied from CalcOrbitForTime
+            Vector3d EarthPos = mainBody.position;
+            Vector3d EarthAxis = mainBody.angularVelocity.normalized;
+
+            double targetTime = Planetarium.GetUniversalTime() + flightTime * 24d * 3600d + delayTime;
+            Vector3d targetPos = target.getPositionAtUT(targetTime);
+
+            Vector3d upVector = Quaternion.AngleAxis((float)(delayTime * 360d / mainBody.rotationPeriod), EarthAxis) * (launchPos - EarthPos).normalized;
+            // end of copied code
+
+            // TLI takes place at the point of the orbit that is opposite to the future position of the Moon
+            Vector3d tliUpVector = (EarthPos - targetPos).normalized;
+
+            // Need to calculate 0-360 degree angle in prograde direction between upVector at launch and at the time of the TLI.
+            float rotationAngle;
+            Vector3 rotationAxis;
+            Quaternion rotationFromLaunchToTLI = new Quaternion();
+            rotationFromLaunchToTLI.SetFromToRotation(upVector, tliUpVector);
+            rotationFromLaunchToTLI.ToAngleAxis(out rotationAngle, out rotationAxis);
+            // Sometimes this rotation is prograde, sometimes retrograde. We need only prograde rotation.
+            if (Vector3d.Dot(rotationAxis.normalized, EarthAxis) > 0)
+            {
+                // rotationAxis is pointing roughly in the direction of Earth rotation axis => rotation is prograde => do nothing
+            }
+            else
+            {
+                // rotationAxis is pointing roughly opposite to Earth rotation axis => rotation is retrograde => rotate the other way
+                rotationAngle = (-rotationAngle) % 360;
+            }
+            
+            // The angle is converted to time in orbit
+            double orbitRadius = mainBody.Radius + tliAltitudeKM * 1000;
+            double orbitPeriod = 2 * Math.PI * Math.Sqrt( (orbitRadius*orbitRadius*orbitRadius) / gravParameter );
+            double flightTimeBeforeTLI = rotationAngle / 360 * orbitPeriod;
+
+            // Launch and maneuver planning take some time, say 15 minutes. If time to TLI is less than that, add an orbit.
+            if (flightTimeBeforeTLI < 15*60)
+            {
+                flightTimeBeforeTLI += orbitPeriod;
+            }
+
+            return flightTimeBeforeTLI;
+        }
+
+        private double EstimateDV(CelestialBody target, Vector3d launchPos)
+        {
+            float dV = float.NaN;
+
+            // Search in this range
+            const float minPossibleDV = 3000;
+            const float maxPossibleDV = 4200;
+            
+            // Current search range, will be gradually narrowed
+            float lowerBound = minPossibleDV;
+            float upperBound = maxPossibleDV;
+
+            // Max. 16 attempts, then return whatever value was found
+            for (int i = 0; i < 16; i++) 
+            {
+                // guess dV
+                dV = (lowerBound + upperBound) / 2;
+
+                // calculate flight time for this dV
+                double flightTimeAfterTLI = EstimateFlightTimeAfterTLI(target, dV);
+                double flightTimeBeforeTLI = EstimateFlightTimeBeforeTLI(target, launchPos, 0d);
+                double estimatedFlightTime = flightTimeBeforeTLI + flightTimeAfterTLI;
+                
+                // Debug.Log(i + " " + dV + " " + flightTime + " " + flightTimeBeforeTLI + " " + flightTimeAfterTLI + " " + estimatedFlightTime);
+                
+                if (Double.IsNaN(flightTimeAfterTLI))
+                {
+                    // dV is so low that target is unreachable, set lower bound to current guess and try again
+                    lowerBound = dV;
+                    continue;
+                }
+                else if (estimatedFlightTime > (flightTime * (24*60*60) + 60))
+                {
+                    // dV is too low, set lower bound to current guess and try again
+                    lowerBound = dV;
+                    continue;
+                }
+                else if (estimatedFlightTime < (flightTime * (24*60*60) - 60))
+                {
+                    // dV is too high, set upper bound to current guess and try again
+                    upperBound = dV;
+                    continue;
+                }
+                else 
+                {
+                    // correct flight time with this dV
+                    break;
+                }
+            }
+
+            if (dV == minPossibleDV || dV == maxPossibleDV)
+            {
+                // dV is incorrect, the correct value is outside the initial search range
+                dV = float.NaN;
+            }
+
+            return dV;
+        }
+
         private string FormatTime(double t)
         {
             t = Math.Round(t);
@@ -422,22 +635,91 @@ namespace LunarTransferPlanner
                     double firstLaunchETA = EstimateLaunchTime(target, launchPos, latitude, 0d);
                     double secondLaunchETA = EstimateLaunchTime(target, launchPos, latitude, firstLaunchETA + 3600d);
 
+                    double dV = EstimateDV(target, launchPos);
+
                     GUILayout.Space(4);
+                    GUILayout.Label("Required dV", GUILayout.ExpandWidth(true));
+                    GUILayout.Box(new GUIContent(String.Format("{0:0 m/s}", dV), "Required dV for the selected flight time"), GUILayout.MinWidth(100));
+
+                    GUILayout.Space(4);
+                    GUILayout.BeginHorizontal();
                     GUILayout.Label("Launch Now Incl", GUILayout.ExpandWidth(true));
-                    GUILayout.Box(new GUIContent($"{(launchOrbit.azimuth > 90d ? -launchOrbit.inclination : launchOrbit.inclination):F2}°",
+                    bool showParking0_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));
+                    GUILayout.EndHorizontal();
+
+                    GUILayout.Space(4);
+                    GUILayout.Box(new GUIContent($"{(launchOrbit.azimuth > 90d ? -launchOrbit.inclination : launchOrbit.inclination):F2}\u00B0",
                         "Launch to this inclination now to reach a Lunar parking orbit"), GUILayout.MinWidth(100));
 
                     string tooltip = latitude >= target.orbit.inclination ?
                         "Launch at this time for an Easterly launch to Lunar parking orbit" :
                         "Launch at this time for a low inclination launch to Lunar parking orbit";
 
-                    GUILayout.Space(4);
-                    GUILayout.Label("First Window", GUILayout.ExpandWidth(true));
-                    GUILayout.Box(new GUIContent(FormatTime(firstLaunchETA), tooltip), GUILayout.MinWidth(100));
+                    if (showParking0_pressed)
+                    {
+                        showParking0 = !showParking0;
+                        // Doing this forces the window to be resized
+                        // Without it, the window will become bigger when controls expand, but never become smaller again
+                        windowRect = new Rect(windowRect.xMin, windowRect.yMin, -1, -1);
+                    }
+
+                    if (showParking0) 
+                    {
+                        double timeInOrbit0 = EstimateFlightTimeBeforeTLI(target, launchPos, 0d);
+                        GUILayout.Space(4);
+                        GUILayout.Label("Time in parking orbit", GUILayout.ExpandWidth(true));
+                        GUILayout.Box(new GUIContent(FormatTime(timeInOrbit0), ""), GUILayout.MinWidth(100));
+                    }
 
                     GUILayout.Space(4);
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label("First Window     ", GUILayout.ExpandWidth(true));
+                    bool showParking1_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));
+                    GUILayout.EndHorizontal();
+
+                    GUILayout.Space(4);
+                    GUILayout.Box(new GUIContent(FormatTime(firstLaunchETA), tooltip), GUILayout.MinWidth(100));
+
+                    if (showParking1_pressed)
+                    {
+                        showParking1 = !showParking1;
+                        // Doing this forces the window to be resized
+                        // Without it, the window will become bigger when controls expand, but never become smaller again
+                        windowRect = new Rect(windowRect.xMin, windowRect.yMin, -1, -1);
+                    }
+
+                    if (showParking1) 
+                    {
+                        double timeInOrbit1 = EstimateFlightTimeBeforeTLI(target, launchPos, firstLaunchETA);
+                        GUILayout.Space(4);
+                        GUILayout.Label("Time in parking orbit", GUILayout.ExpandWidth(true));
+                        GUILayout.Box(new GUIContent(FormatTime(timeInOrbit1), ""), GUILayout.MinWidth(100));
+                    }
+
+                    GUILayout.Space(4);
+                    GUILayout.BeginHorizontal();
                     GUILayout.Label("Second Window", GUILayout.ExpandWidth(true));
+                    bool showParking2_pressed = GUILayout.Button("...", GUILayout.MinWidth(20));
+                    GUILayout.EndHorizontal();
+
+                    GUILayout.Space(4);
                     GUILayout.Box(new GUIContent(FormatTime(secondLaunchETA), tooltip), GUILayout.MinWidth(100));
+
+                    if (showParking2_pressed)
+                    {
+                        showParking2 = !showParking2;
+                        // Doing this forces the window to be resized
+                        // Without it, the window will become bigger when controls expand, but never become smaller again
+                        windowRect = new Rect(windowRect.xMin, windowRect.yMin, -1, -1);
+                    }
+
+                    if (showParking2) 
+                    {
+                        double timeInOrbit2 = EstimateFlightTimeBeforeTLI(target, launchPos, secondLaunchETA);
+                        GUILayout.Space(4);
+                        GUILayout.Label("Time in parking orbit", GUILayout.ExpandWidth(true));
+                        GUILayout.Box(new GUIContent(FormatTime(timeInOrbit2), ""));
+                    }
 
                     GUILayout.Label("Warp Margin (sec)", GUILayout.ExpandWidth(true));
                     MakeNumberEditField(ref warpMargin, ref nextTickWM, 0, 5f, 0f);
@@ -477,7 +759,7 @@ namespace LunarTransferPlanner
                         {
                             TimeWarp.fetch.WarpTo(Planetarium.GetUniversalTime() + firstLaunchETA - warpMargin);
                         }
-                }
+                    }
                 }
 
             GUILayout.EndVertical();

--- a/LunarTransferPlanner.cs
+++ b/LunarTransferPlanner.cs
@@ -314,7 +314,7 @@ namespace LunarTransferPlanner
             double t = startTime;
             OrbitData launchOrbit = CalcOrbitForTime(target, launchPos, t);
 
-            if (Math.Abs(latitude) >= target.orbit.inclination)
+            if (latitude >= target.orbit.inclination)
             {
                 // High latitude path - find the next easterly launch to the target
                 while (Math.Abs(launchOrbit.azimuth - targetAz) > 0.01d)
@@ -654,7 +654,7 @@ namespace LunarTransferPlanner
                     GUILayout.Box(new GUIContent($"{(launchOrbit.azimuth > 90d ? -launchOrbit.inclination : launchOrbit.inclination):F2}\u00B0",
                         "Launch to this inclination now to reach a Lunar parking orbit"), GUILayout.MinWidth(100));
 
-                    string tooltip = Math.Abs(latitude) >= target.orbit.inclination ?
+                    string tooltip = latitude >= target.orbit.inclination ?
                         "Launch at this time for an Easterly launch to Lunar parking orbit" :
                         "Launch at this time for a low inclination launch to Lunar parking orbit";
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Lunar Transfer Planner
 ========================================
-Provides a GUI for Lunar transfer planning for RSS.
+Provides a GUI for planning a Lunar transfer for RSS.
 Select the expected flight time to the Moon, i.e. the time from leaving Earth orbit to Lunar periapsis, this defaults to 4 days. The delta-V required for this maneuver is also given.
 The correct launch inclination for immediate launch is shown, and your current latitude is shown for reference. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in parking orbit that you will spend while waiting for the lunar transfer.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Lunar Transfer Planner
 ========================================
 Provides a GUI for planning a Lunar transfer for RSS.
 Select the expected flight time to the Moon, i.e. the time from leaving Earth orbit to Lunar periapsis, this defaults to 4 days. The delta-V required for this maneuver is also given.
-The correct launch inclination for immediate launch is shown. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in parking orbit that you will spend while waiting for the lunar transfer.
+The correct launch inclination for immediate launch is shown. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in a given parking orbit that you will spend while waiting for the lunar transfer.
 
 Forum Thread: 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Lunar Transfer Planner
 ========================================
 Provides a GUI for planning a Lunar transfer for RSS.
 Select the expected flight time to the Moon, i.e. the time from leaving Earth orbit to Lunar periapsis, this defaults to 4 days. The delta-V required for this maneuver is also given.
-The correct launch inclination for immediate launch is shown, and your current latitude is shown for reference. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in parking orbit that you will spend while waiting for the lunar transfer.
+The correct launch inclination for immediate launch is shown. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in parking orbit that you will spend while waiting for the lunar transfer.
 
 Forum Thread: 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Lunar Transfer Planner
 ========================================
 Provides a GUI for Lunar transfer planning for RSS.
-Select the expecteed flight time to the Moon, i.e. the time from leaving Earth orbit to Lunar periapsis, this defaults to 4 days.
-The correct launch inclination for immediate launch is shown. The next two windows for a minimum inclination (i.e. Easterly) launch are also given.
+Select the expected flight time to the Moon, i.e. the time from leaving Earth orbit to Lunar periapsis, this defaults to 4 days. The delta-V required for this maneuver is also given.
+The correct launch inclination for immediate launch is shown, and your current latitude is shown for reference. The first two windows for a minimum inclination (i.e. Easterly) launch are also given, along with the time in parking orbit that you will spend while waiting for the lunar transfer.
 
 Forum Thread: 
 


### PR DESCRIPTION
DISCLAIMER: This PR was fully written by test_account (except for the README changes), and any credit for it should be given to them instead of me. I have reopened their PR in https://github.com/KSP-RO/LunarTransferPlanner/pull/3 with permission, as the account of that PR was previously deleted.

This PR adds a "Required Delta-V" field, along with the time in parking orbit for certain launch times that the person will need to wait before the maneuver actually takes place. These parking orbit wait times are collapsible with the "..." button. The PR also edits the README to be more accurate.

Screenshots showing the new GUI are below:

![image](https://github.com/user-attachments/assets/d94aa491-3023-4b64-a9a2-c749d9c4da1e) ![image](https://github.com/user-attachments/assets/059a623e-aaac-4736-ae14-2fa7f949c408)

Permission:
![image](https://github.com/user-attachments/assets/bd432004-96aa-4260-ab78-893d7fee86d0)


As it seems that RCrockford has been procrastinating a little bit on merging nazfib's PR (no offense, irl is busy I get it), I have published a release with [nazfib's PR](https://github.com/KSP-RO/LunarTransferPlanner/pull/8) and all 3 of my PRs [here](https://github.com/Clayell/LunarTransferPlanner/releases/tag/v1.0.0) if anyone wants to use it until a new LTP release is published and doesn't know how to compile the code themselves. I have confirmed that all PRs work as intended.